### PR TITLE
Allow functions to be passed in for banner text

### DIFF
--- a/tasks/usebanner.js
+++ b/tasks/usebanner.js
@@ -26,14 +26,16 @@ module.exports = function(grunt) {
 
         var linebreak = options.linebreak ? grunt.util.linefeed : '';
 
+        var banner;
+
         // Iterate over the list of files and add the banner or footer
         this.files.forEach( function( file ) {
             file.src.forEach( function( src ) {
 
                 if ( grunt.file.isFile( src ) ) {
-
+                    typeof( options.banner ) === 'function' ? banner = options.banner( src ) : banner = options.banner;
                     grunt.file.write( src,
-                        options.position === 'top' ? options.banner + linebreak + grunt.file.read( src ) : grunt.file.read( src ) + linebreak + options.banner
+                        options.position === 'top' ? banner + linebreak + grunt.file.read( src ) : grunt.file.read( src ) + linebreak + banner
                     );
 
                 	grunt.verbose.writeln( 'Banner added to file ' + src.cyan );


### PR DESCRIPTION
Hopefully this manages to keep things simple enough!  It really is pretty convenient:

``` coffeescript
  usebanner:
      main:
        options:
          banner: (file) -> "//CoffeeScript generated from #{file.replace('.js', '.coffee')}"
```

Thoughts?
