### PR TITLE
Added support for conditional banners via pattern

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,9 +86,36 @@ module.exports = function( grunt ) {
                 files: {
                     src: [ 'test/tmp/someProcess.js' ]
                 }
+            },
+
+            bannerMatchPatternTop: {
+                options: {
+                    position: 'top',
+                    banner: '// the banner',
+                    pattern: 'var variable',
+                    linebreak: true
+
+                },
+                files: {
+                    src: [
+                        'test/tmp/someMatchingPatternTop.js',
+                        'test/tmp/someNotMatchingPattern.js'
+                    ]
+                }
+            },
+
+            bannerMatchPatternBottom: {
+                options: {
+                    position: 'bottom',
+                    banner: '// the banner',
+                    pattern: 'var variable'
+                },
+                files: {
+                    src: [
+                        'test/tmp/someMatchingPatternBottom.js'
+                    ]
+                }
             }
-
-
         },
 
         // Unit tests.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Default value: ``
 
 The text to use as a banner.  Templated strings are perfectly acceptable and encouraged.
 
+#### options.pattern
+Type: `String`
+
+Allows the banner to be added only if the supplied pattern matches. 
+
+
 #### options.linebreak
 Type: `Boolean`
 Default value: `true`

--- a/tasks/usebanner.js
+++ b/tasks/usebanner.js
@@ -26,6 +26,13 @@ module.exports = function(grunt) {
             options.position = 'top';
         }
 
+        var re = null;
+
+        if (options.pattern)
+        {
+            re = new RegExp(options.pattern);
+        }
+
         var linebreak = options.linebreak ? grunt.util.linefeed : '';
 
         // Iterate over the list of files and add the banner or footer
@@ -33,12 +40,19 @@ module.exports = function(grunt) {
             file.src.forEach( function( src ) {
                 if ( grunt.file.isFile( src ) ) {
 
+                    var fileContents = grunt.file.read( src );
+
+                    if (re && !re.test(fileContents))
+                    {
+                        return;
+                    }
+
                     if ( typeof options.process === 'function' ) {
                         options.banner = options.process( src );
                     }
 
                     grunt.file.write( src,
-                        options.position === 'top' ? options.banner + linebreak + grunt.file.read( src ) : grunt.file.read( src ) + linebreak + options.banner
+                        options.position === 'top' ? options.banner + linebreak + fileContents : fileContents + linebreak + options.banner
                     );
 
                     grunt.verbose.writeln( 'Banner added to file ' + src.cyan );

--- a/test/banner_test.js
+++ b/test/banner_test.js
@@ -65,5 +65,29 @@ exports.banner = {
         test.equal( actual, expected, 'should add a banner with a custom process task for creating the banner' );
 
         test.done();
+    },
+
+    bannerMatchPatternTop: function( test ) {
+        test.expect( 3 );
+
+        var actualTop = grunt.file.read( 'test/tmp/someMatchingPatternTop.js' );
+        var expectedTop = grunt.file.read( 'test/expected/someMatchingPatternTop.js' );
+
+        test.equal( actualTop, expectedTop, 'should add a banner to the top of a file if matching pattern' );
+
+
+        var actualNoMatch = grunt.file.read( 'test/tmp/someNotMatchingPattern.js' );
+        var expectedNoMatch = grunt.file.read( 'test/expected/someNotMatchingPattern.js' );
+
+        test.equal( actualNoMatch, expectedNoMatch, 'should not add a banner to the top of a file if not matching pattern' );
+
+
+        var actualBottom = grunt.file.read( 'test/tmp/someMatchingPatternBottom.js' );
+        var expectedBottom = grunt.file.read( 'test/expected/someMatchingPatternBottom.js' );
+
+        test.equal( actualBottom, expectedBottom, 'should add a banner to the bottom of a file if matching pattern' );
+
+
+        test.done();
     }
 };

--- a/test/expected/someMatchingPatternBottom.js
+++ b/test/expected/someMatchingPatternBottom.js
@@ -1,0 +1,2 @@
+var variable = "this is a variable";
+// the banner

--- a/test/expected/someMatchingPatternTop.js
+++ b/test/expected/someMatchingPatternTop.js
@@ -1,0 +1,2 @@
+// the banner
+var variable = "this is a variable";

--- a/test/expected/someNotMatchingPattern.js
+++ b/test/expected/someNotMatchingPattern.js
@@ -1,0 +1,1 @@
+var otherVariable = "this is a variable";

--- a/test/fixtures/someMatchingPatternBottom.js
+++ b/test/fixtures/someMatchingPatternBottom.js
@@ -1,0 +1,1 @@
+var variable = "this is a variable";

--- a/test/fixtures/someMatchingPatternTop.js
+++ b/test/fixtures/someMatchingPatternTop.js
@@ -1,0 +1,1 @@
+var variable = "this is a variable";

--- a/test/fixtures/someNotMatchingPattern.js
+++ b/test/fixtures/someNotMatchingPattern.js
@@ -1,0 +1,1 @@
+var otherVariable = "this is a variable";


### PR DESCRIPTION
I was looking for a way to only include banner for a subset of my sources, which was not supported. 

I've implemented a new option called "pattern", which is tested against the file contents. The banner will only be injected if there is a match. The option is default off, so will not affect existing usage. Tests included.


This is very neat if you are working with IE typescript, and need to add /* istanbul ignore next */ to all those pesky "var __extends = this.__extends || function (d, b) {" statements. Hope others can benefit!