### PR TITLE
Switch to `u221A` for the OK character.

### DIFF
--- a/tasks/usebanner.js
+++ b/tasks/usebanner.js
@@ -59,7 +59,7 @@ module.exports = function ( grunt ) {
             });
         });
 
-        grunt.log.writeln( '✔'.magenta + ' grunt-banner completed successfully' );
+        grunt.log.writeln( '\u221A'.magenta + ' grunt-banner completed successfully' );
 
     });
 


### PR DESCRIPTION
This works on Windows with Lucida Console too along with Unix shells.

Before:
![before](https://cloud.githubusercontent.com/assets/349621/7408209/401e7ede-ef23-11e4-89d0-bc8527904a58.png)

After:
![after](https://cloud.githubusercontent.com/assets/349621/7408211/42e95062-ef23-11e4-846b-02cc92260880.png)



I couldn't find any other solution, but if one knows another, please let me know.