### PR TITLE
Update dependencies to latest stabe versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,16 +28,16 @@
     "LICENSE-MIT"
   ],
   "dependencies": {
-    "chalk": "^1.1.0"
+    "chalk": "^2.4.2"
   },
   "devDependencies": {
-    "grunt": "^1.0.1",
-    "grunt-contrib-clean": "^1.0.0",
+    "grunt": "^1.0.3",
+    "grunt-contrib-clean": "^2.0.0",
     "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-nodeunit": "^1.0.0",
-    "load-grunt-tasks": "^3.2.0",
-    "time-grunt": "^1.2.1"
+    "grunt-contrib-jshint": "^2.0.0",
+    "grunt-contrib-nodeunit": "^2.0.0",
+    "load-grunt-tasks": "^4.0.0",
+    "time-grunt": "^2.0.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"


### PR DESCRIPTION
Your excellent plugin is reported as deprecated by David code quality/deprecation tool.  See screenshot attached.
![image](https://user-images.githubusercontent.com/6531012/51068989-424c2200-15f4-11e9-8bad-31db0b81b4ff.png)

I have updated package,json dependencies with latest stable version and test it with your test task.

Sole exception: time-grunt@2.0.0: 
Deprecated because Grunt is practically unmaintained. Move on to something better.
This package will continue to work with Grunt v1, but it will not receive any updates.

Let me know if you need more tests or information.  It is my first contribution, I may need some directions.

Best,